### PR TITLE
Issue 12: Fixes runtime config lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ElixirLokaliseApi
 
 ![Hex.pm](https://img.shields.io/hexpm/v/elixir_lokalise_api)
+
 [![Build Status](https://travis-ci.com/lokalise/elixir-lokalise-api.svg?branch=master)](https://travis-ci.com/lokalise/elixir-lokalise-api)
+
 [![Coverage Status](https://coveralls.io/repos/github/lokalise/elixir-lokalise-api/badge.svg)](https://coveralls.io/github/lokalise/elixir-lokalise-api)
 
 Official Elixir interface for Lokalise APIv2.
@@ -13,7 +15,7 @@ Add a new depedency to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:elixir_lokalise_api}
+    {:elixir_lokalise_api, "~> 2.0"}
   ]
 end
 ```
@@ -52,9 +54,11 @@ process.status |> IO.puts # => "finished"
 
 ## Documentation
 
-All documentation and usage examples can be found at [lokalise.github.io/elixir-lokalise-api](https://lokalise.github.io/elixir-lokalise-api/).
+All documentation and usage examples can be found at
+[lokalise.github.io/elixir-lokalise-api](https://lokalise.github.io/elixir-lokalise-api/).
 
-Brief API reference is also available at [hexdocs.pm](https://hexdocs.pm/elixir_lokalise_api/).
+Brief API reference is also available at
+[hexdocs.pm](https://hexdocs.pm/elixir_lokalise_api/).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ end
 Put your Lokalise API token into `config.exs`:
 
 ```elixir
-config :your_app, api_token: "LOKALISE_API_TOKEN"
+config :elixir_lokalise_api, api_token: "LOKALISE_API_TOKEN"
 ```
 
 If you are using ENV variables, use the following approach:
 
 ```elixir
-config :your_app, api_token: {:system, "LOKALISE_API_TOKEN"}
+config :elixir_lokalise_api, api_token: {:system, "LOKALISE_API_TOKEN"}
 ```
 
 Now you can perform API calls:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,3 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :elixir_lokalise_api,
   api_token: {:system, "LOKALISE_API_TOKEN"}

--- a/config/docs.exs
+++ b/config/docs.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,7 @@
-use Mix.Config
+import Config
 
 config :elixir_lokalise_api,
-  api_token: {:system, "LOKALISE_API_TOKEN"},
+  api_token: "LOKALISE_API_TOKEN",
   request_options: [
     timeout: 5000,
     recv_timeout: 5000

--- a/lib/elixir_lokalise_api/config.ex
+++ b/lib/elixir_lokalise_api/config.ex
@@ -6,22 +6,17 @@ defmodule ElixirLokaliseApi.Config do
   """
 
   @doc """
-  Returns package configuration defined inside the `mix.exs` file
-  """
-  def app_config, do: Mix.Project.config()
-
-  @doc """
   Returns Lokalise APIv2 token. Set it inside your `mix.exs`:
       config :elixir_lokalise_api, api_token: "YOUR_API_TOKEN"
   """
-  def api_token, do: from_env(app_config()[:app], :api_token)
+  def api_token, do: from_env(:api_token)
 
-  def request_options, do: from_env(app_config()[:app], :request_options, Keyword.new())
+  def request_options, do: from_env(:request_options, Keyword.new())
 
   @doc """
   Returns package version
   """
-  def version, do: app_config()[:version]
+  def version, do: from_env(:version, "1.0.0")
 
   @doc """
   Returns the base URL of the Lokalise APIv2
@@ -32,10 +27,10 @@ defmodule ElixirLokaliseApi.Config do
   A light wrapper around `Application.get_env/2`, providing automatic support for
   `{:system, "VAR"}` tuples. Based on https://github.com/danielberkompas/ex_twilio/blob/master/lib/ex_twilio/config.ex
   """
-  def from_env(otp_app, key, default \\ nil)
+  def from_env(key, default \\ nil)
 
-  def from_env(otp_app, key, default) do
-    otp_app
+  def from_env(key, default) do
+    :elixir_lokalise_api
     |> Application.get_env(key, default)
     |> read_from_system(default)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirLokaliseApi.MixProject do
   def project do
     [
       app: :elixir_lokalise_api,
-      version: "1.0.0",
+      version: "2.0.0",
       elixir: "~> 1.10",
       name: "ElixirLokaliseApi",
       description: "Lokalise APIv2 interface for Elixir.",
@@ -37,7 +37,7 @@ defmodule ElixirLokaliseApi.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:httpoison, ">= 0.9.0"},
+      {:httpoison, "~> 1.8.0"},
       {:jason, "~> 1.2"},
       {:ex_doc, "~> 0.23", only: [:dev, :test]},
       {:exvcr, "~> 0.11", only: :test},

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ElixirLokaliseApi.MixProject do
     [
       app: :elixir_lokalise_api,
       version: "1.0.0",
-      elixir: "~> 1.2",
+      elixir: "~> 1.10",
       name: "ElixirLokaliseApi",
       description: "Lokalise APIv2 interface for Elixir.",
       source_url: "https://github.com/lokalise/elixir-lokalise-api",

--- a/test/elixir_lokalise_api/config_test.exs
+++ b/test/elixir_lokalise_api/config_test.exs
@@ -4,17 +4,14 @@ defmodule ElixirLokaliseApi.ConfigTest do
   alias ElixirLokaliseApi.Config
 
   test "from_env returns a plain value" do
-    app = Config.app_config()[:app]
-    assert Config.from_env(app, :request_options)
+    assert Config.from_env(:request_options)
   end
 
   test "from_env returns a value under system" do
-    app = Config.app_config()[:app]
-    assert Config.from_env(app, :api_token) != nil
+    assert Config.from_env(:api_token) != nil
   end
 
   test "from_env returns a default value when missing" do
-    app = Config.app_config()[:app]
-    assert Config.from_env(app, :missing, :ok) == :ok
+    assert Config.from_env(:missing, :ok) == :ok
   end
 end


### PR DESCRIPTION
Replaces the dynamic lookup of `:your_app` with the hardcoded `:elixir_lokalise_api` which breaks the current config but:
1. streamlines the config with other libraries, and
2. ensures that the library can be used by elixir projects that are built with `mix release` or `mix escript.build`.

Closes #12 